### PR TITLE
Simplify SubsettingItem to SimpleCardWidget and clean up

### DIFF
--- a/src/tower_iq/gui/pages/connection_settings_page.py
+++ b/src/tower_iq/gui/pages/connection_settings_page.py
@@ -8,8 +8,8 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QWidget, QVBoxLayout, QScrollArea
 from qfluentwidgets import FluentIcon, PushButton
 
-from ..utils.settings_item_card import SettingsItemCard
-from ..utils.expandable_settings_card import ExpandableSettingsCard, SubsettingItem
+from ..utils.expandable_settings_card import ExpandableCardGroup, SubsettingItem
+from ..utils.utils_gui import rotate_icon
 
 
 class ConnectionSettingsPage(QWidget):
@@ -51,11 +51,13 @@ class ConnectionSettingsPage(QWidget):
         
     def setup_content(self, content_layout: QVBoxLayout):
         """Set up the connection settings content."""
-        # Create the expandable auto-connect card
-        self.auto_connect_card = ExpandableSettingsCard(
+        # Create the expandable auto-connect card group
+        self.auto_connect_card = ExpandableCardGroup(
             title="Auto-Connect",
             content="Automatically connect to an Android emulator and process on startup",
-            icon=FluentIcon.CONNECT
+            header_icon=FluentIcon.CONNECT,
+            expand_icon=FluentIcon.ARROW_DOWN,
+            collapse_icon=rotate_icon(FluentIcon.ARROW_DOWN,16,16,180),
         )
         
         # Set current value from config
@@ -66,26 +68,22 @@ class ConnectionSettingsPage(QWidget):
         # Connect toggle signal
         self.auto_connect_card.toggle_changed.connect(self.on_auto_connect_changed)
         
-        # Create Device subsetting
+        # Create Device subsetting card
         self.device_select_button = PushButton("Select", self)
         self.device_select_button.clicked.connect(self.on_device_select_clicked)
         
-        self.device_subsetting = SubsettingItem(
-            label="Device",
-            control_widget=self.device_select_button
-        )
-        self.auto_connect_card.add_subsetting(self.device_subsetting)
+        self.device_card = SubsettingItem("Device", self.device_select_button)
         
-        # Create Process subsetting
+        # Create Process subsetting card
         self.process_select_button = PushButton("Select", self)
         self.process_select_button.clicked.connect(self.on_process_select_clicked)
         self.process_select_button.setEnabled(False)  # Initially disabled
         
-        self.process_subsetting = SubsettingItem(
-            label="Process",
-            control_widget=self.process_select_button
-        )
-        self.auto_connect_card.add_subsetting(self.process_subsetting)
+        self.process_card = SubsettingItem("Process", self.process_select_button)
+        
+        # Add the subsetting cards to the expandable group
+        self.auto_connect_card.add_card(self.device_card)
+        self.auto_connect_card.add_card(self.process_card)
         
         # Load saved device and process selections
         self.load_saved_selections()

--- a/src/tower_iq/gui/stylesheets/stylesheets.py
+++ b/src/tower_iq/gui/stylesheets/stylesheets.py
@@ -90,38 +90,20 @@ SettingsItemCard CaptionLabel {{
 }}
 """
 
-# Styles for the expandable settings card
-EXPANDABLE_SETTINGS_CARD_QSS = """
-ExpandableSettingsCard {{
-    background-color: {sub_card_bg};
-    border: 1px solid {sub_card_border};
+# Styles for the expandable card group (simplified)
+EXPANDABLE_CARD_GROUP_QSS = """
+#HeaderCard {{
     border-radius: 8px;
 }}
-ExpandableSettingsCard BodyLabel {{
-    background-color: transparent;
-    font-size: 14px;
-    font-weight: 500;
-}}
-ExpandableSettingsCard CaptionLabel {{
-    background-color: transparent;
-    font-size: 12px;
-}}
-QWidget#expandable_content_frame {{
-    background-color: transparent;
-    border: none;
-}}
-"""
 
-# Styles for subsetting items
-SUBSETTING_ITEM_QSS = """
-SubsettingItem {{
+#HeaderCard BodyLabel {{
     background-color: transparent;
     border: none;
 }}
-SubsettingItem BodyLabel#subsetting_label {{
+
+#HeaderCard CaptionLabel {{
     background-color: transparent;
-    font-size: 13px;
-    font-weight: 400;
+    border: none;
 }}
 """
 
@@ -218,8 +200,7 @@ def get_themed_stylesheet() -> str:
     return (
         SETTINGS_CATEGORY_CARD_QSS.format(**theme_palette) +
         SETTINGS_ITEM_CARD_QSS.format(**theme_palette) +
-        EXPANDABLE_SETTINGS_CARD_QSS.format(**theme_palette) +
-        SUBSETTING_ITEM_QSS.format(**theme_palette) +
+        EXPANDABLE_CARD_GROUP_QSS.format(**theme_palette) +
         SETTINGS_CATEGORY_PAGE_QSS.format(**theme_palette) +
         PAGE_HEADER_QSS.format(**theme_palette) +
         CONTENT_PAGE_QSS.format(**theme_palette) +


### PR DESCRIPTION
Refactor expandable settings card to use `CardWidget` for automatic theme handling and remove complex styling.

The previous implementation had complex, conflicting styling logic and manual theme handling. By leveraging `CardWidget` for `SubsettingItem` and the header, theme changes are now handled automatically by the framework, significantly simplifying the codebase and resolving previous styling issues.

---

[Open in Web](https://cursor.com/agents?id=bc-6f078c74-bac2-4d85-8061-fb2a9020dbe4) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6f078c74-bac2-4d85-8061-fb2a9020dbe4) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)