### PR TITLE
Remove trailing space from device and process tables

### DIFF
--- a/src/tower_iq/gui/pages/connection_page.py
+++ b/src/tower_iq/gui/pages/connection_page.py
@@ -12,7 +12,7 @@ from ..utils.content_page import ContentPage
 from ...core.session import ConnectionState, ConnectionSubState
 from PyQt6.QtWidgets import (
     QHBoxLayout, QVBoxLayout, QLabel, QStackedWidget, QWidget,
-    QGroupBox, QTextEdit, QFrame, QHeaderView, QTableWidgetItem
+    QGroupBox, QTextEdit, QFrame, QHeaderView, QTableWidgetItem, QSizePolicy
 )
 from qfluentwidgets import (SwitchButton, FluentIcon, PushButton, TableWidget, TableItemDelegate, isDarkTheme,
                             ProgressRing, BodyLabel, InfoBar, InfoBarPosition, CardWidget, SimpleCardWidget)
@@ -120,6 +120,9 @@ class ConnectionPage(QWidget):
         table.setBorderRadius(8)
         table.setWordWrap(False)
         table.setSortingEnabled(False)
+        
+        # Set size policy to prevent extra space after rows
+        table.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
         
         vertical_header = table.verticalHeader()
         if vertical_header is not None:


### PR DESCRIPTION
Set table size policy to minimum height to remove extra space after the last row in device and process tables.

Previously, tables used a default size policy that allowed them to expand vertically beyond their content, leading to empty space below the last row. This change ensures tables only take the minimum vertical space required for their content.

---
<a href="https://cursor.com/background-agent?bcId=bc-3b1c3e1a-96e1-4dd2-815b-0d75bdc98c10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3b1c3e1a-96e1-4dd2-815b-0d75bdc98c10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>