### PR TITLE
Regenerate requirements from Poetry lock

### DIFF
--- a/docs/dependency_workflow.md
+++ b/docs/dependency_workflow.md
@@ -1,0 +1,48 @@
+# Dependency Management Workflow
+
+This project uses [Poetry](https://python-poetry.org/) as the source of truth for
+Python dependencies. The `poetry.lock` file captures the fully resolved dependency
+graph and should be treated as canonical. When `requirements.txt` is needed (for
+example, in deployment environments that rely on `pip install -r requirements.txt`),
+regenerate it from the lock file instead of editing it manually.
+
+## Generating `requirements.txt`
+
+1. Ensure the lock file is up to date:
+   ```bash
+   poetry lock --no-update
+   ```
+2. If the `poetry-plugin-export` plugin is available, run:
+   ```bash
+   poetry export -f requirements.txt --without-hashes -o requirements.txt
+   ```
+3. In offline environments where the plugin cannot be installed, use the helper
+   script committed with this repository:
+   ```bash
+   python tools/export_requirements.py
+   ```
+
+The generated file pins all main (runtime) dependencies and preserves platform
+markers so that OS-specific wheels such as `pywin32` or the macOS `pyobjc`
+family are only installed where appropriate. Review the file to confirm that:
+
+- Only third-party packages are present (stdlib modules such as `sqlite3` should
+  never appear because they are not tracked by Poetry).
+- Expected runtime dependencies such as `pandas`, `aiohttp`, and `sqlcipher3-wheels`
+  are listed with exact versions that match `poetry.lock`.
+
+## Validating the Environment (Optional)
+
+After updating `requirements.txt`, you can optionally test the result in a clean
+virtual environment:
+
+```bash
+python -m venv .venv-test
+source .venv-test/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+python start_backend.py  # or the relevant entry point
+```
+
+This smoke test confirms that the exported requirements are sufficient to start
+the backend outside of Poetry's environment.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,45 +1,203 @@
-# For CPU-based array processing
-numpy
-
-# For Just-In-Time (JIT) compilation on the CPU
-numba
-
-# For plotting and visualization
-matplotlib
-seaborn
-
-# For image processing (PIL/Pillow)
-Pillow
-
-# For FastAPI backend server
-fastapi
-uvicorn[standard]
-pydantic
-
-# For HTTP requests in startup script
-requests
-
-# For structured logging
-structlog
-colorama
-
-# For PyQt6 GUI
-PyQt6
-
-# For async operations
-qasync
-
-# For database operations
-sqlite3
-
-# For configuration management
-pyyaml
-
-# For Frida integration
-frida-tools
-
-# For device communication
-adb-enhanced
-
-# For device detection and identification
-device_detector
+# This requirements.txt was generated from poetry.lock.
+aiohappyeyeballs==2.6.1
+aiohttp==3.12.11
+aiosignal==1.3.2
+altgraph==0.17.4
+attrs==25.3.0
+colorama==0.4.6
+frida==15.2.2
+frida-tools==11.0.0
+frozenlist==1.6.2
+idna==3.10
+macholib==1.16.3 ; sys_platform == "darwin"
+multidict==6.4.4
+numpy==1.26.4
+packaging==25.0
+pandas==2.3.0
+pefile==2023.2.7 ; sys_platform == "win32"
+prompt-toolkit==3.0.51
+propcache==0.3.1
+pycocoa==25.4.8 ; platform_system == "Darwin"
+pycryptodome==3.23.0
+pygments==2.19.1
+pyinstaller==6.14.0
+pyinstaller-hooks-contrib==2025.4
+pyobjc==11.1 ; platform_system == "Darwin"
+pyobjc-core==11.1 ; platform_system == "Darwin"
+pyobjc-framework-accessibility==11.1 ; platform_system == "Darwin" and platform_release >= "20.0"
+pyobjc-framework-accounts==11.1 ; platform_system == "Darwin" and platform_release >= "12.0"
+pyobjc-framework-addressbook==11.1 ; platform_system == "Darwin"
+pyobjc-framework-adservices==11.1 ; platform_system == "Darwin" and platform_release >= "20.0"
+pyobjc-framework-adsupport==11.1 ; platform_system == "Darwin" and platform_release >= "18.0"
+pyobjc-framework-applescriptkit==11.1 ; platform_system == "Darwin"
+pyobjc-framework-applescriptobjc==11.1 ; platform_system == "Darwin" and platform_release >= "10.0"
+pyobjc-framework-applicationservices==11.1 ; platform_system == "Darwin"
+pyobjc-framework-apptrackingtransparency==11.1 ; platform_system == "Darwin" and platform_release >= "20.0"
+pyobjc-framework-audiovideobridging==11.1 ; platform_system == "Darwin" and platform_release >= "12.0"
+pyobjc-framework-authenticationservices==11.1 ; platform_system == "Darwin" and platform_release >= "19.0"
+pyobjc-framework-automaticassessmentconfiguration==11.1 ; platform_system == "Darwin" and platform_release >= "19.0"
+pyobjc-framework-automator==11.1 ; platform_system == "Darwin"
+pyobjc-framework-avfoundation==11.1 ; platform_system == "Darwin" and platform_release >= "11.0"
+pyobjc-framework-avkit==11.1 ; platform_system == "Darwin" and platform_release >= "13.0"
+pyobjc-framework-avrouting==11.1 ; platform_system == "Darwin" and platform_release >= "22.0"
+pyobjc-framework-backgroundassets==11.1 ; platform_system == "Darwin" and platform_release >= "22.0"
+pyobjc-framework-browserenginekit==11.1 ; platform_system == "Darwin" and platform_release >= "23.4"
+pyobjc-framework-businesschat==11.1 ; platform_system == "Darwin" and platform_release >= "18.0"
+pyobjc-framework-calendarstore==11.1 ; platform_system == "Darwin" and platform_release >= "9.0"
+pyobjc-framework-callkit==11.1 ; platform_system == "Darwin" and platform_release >= "20.0"
+pyobjc-framework-carbon==11.1 ; platform_system == "Darwin"
+pyobjc-framework-cfnetwork==11.1 ; platform_system == "Darwin"
+pyobjc-framework-cinematic==11.1 ; platform_system == "Darwin" and platform_release >= "23.0"
+pyobjc-framework-classkit==11.1 ; platform_system == "Darwin" and platform_release >= "20.0"
+pyobjc-framework-cloudkit==11.1 ; platform_system == "Darwin" and platform_release >= "14.0"
+pyobjc-framework-cocoa==11.1 ; platform_system == "Darwin"
+pyobjc-framework-collaboration==11.1 ; platform_system == "Darwin" and platform_release >= "9.0"
+pyobjc-framework-colorsync==11.1 ; platform_system == "Darwin" and platform_release >= "17.0"
+pyobjc-framework-contacts==11.1 ; platform_system == "Darwin" and platform_release >= "15.0"
+pyobjc-framework-contactsui==11.1 ; platform_system == "Darwin" and platform_release >= "15.0"
+pyobjc-framework-coreaudio==11.1 ; platform_system == "Darwin"
+pyobjc-framework-coreaudiokit==11.1 ; platform_system == "Darwin"
+pyobjc-framework-corebluetooth==11.1 ; platform_system == "Darwin" and platform_release >= "14.0"
+pyobjc-framework-coredata==11.1 ; platform_system == "Darwin"
+pyobjc-framework-corehaptics==11.1 ; platform_system == "Darwin" and platform_release >= "19.0"
+pyobjc-framework-corelocation==11.1 ; platform_system == "Darwin" and platform_release >= "10.0"
+pyobjc-framework-coremedia==11.1 ; platform_system == "Darwin" and platform_release >= "11.0"
+pyobjc-framework-coremediaio==11.1 ; platform_system == "Darwin" and platform_release >= "11.0"
+pyobjc-framework-coremidi==11.1 ; platform_system == "Darwin"
+pyobjc-framework-coreml==11.1 ; platform_system == "Darwin" and platform_release >= "17.0"
+pyobjc-framework-coremotion==11.1 ; platform_system == "Darwin" and platform_release >= "19.0"
+pyobjc-framework-coreservices==11.1 ; platform_system == "Darwin"
+pyobjc-framework-corespotlight==11.1 ; platform_system == "Darwin" and platform_release >= "17.0"
+pyobjc-framework-coretext==11.1 ; platform_system == "Darwin"
+pyobjc-framework-corewlan==11.1 ; platform_system == "Darwin" and platform_release >= "10.0"
+pyobjc-framework-cryptotokenkit==11.1 ; platform_system == "Darwin" and platform_release >= "14.0"
+pyobjc-framework-datadetection==11.1 ; platform_system == "Darwin" and platform_release >= "21.0"
+pyobjc-framework-devicecheck==11.1 ; platform_system == "Darwin" and platform_release >= "19.0"
+pyobjc-framework-devicediscoveryextension==11.1 ; platform_system == "Darwin" and platform_release >= "24.0"
+pyobjc-framework-dictionaryservices==11.1 ; platform_system == "Darwin" and platform_release >= "9.0"
+pyobjc-framework-discrecording==11.1 ; platform_system == "Darwin"
+pyobjc-framework-discrecordingui==11.1 ; platform_system == "Darwin"
+pyobjc-framework-diskarbitration==11.1 ; platform_system == "Darwin"
+pyobjc-framework-dvdplayback==11.1 ; platform_system == "Darwin"
+pyobjc-framework-eventkit==11.1 ; platform_system == "Darwin" and platform_release >= "12.0"
+pyobjc-framework-exceptionhandling==11.1 ; platform_system == "Darwin"
+pyobjc-framework-executionpolicy==11.1 ; platform_system == "Darwin" and platform_release >= "19.0"
+pyobjc-framework-extensionkit==11.1 ; platform_system == "Darwin" and platform_release >= "22.0"
+pyobjc-framework-externalaccessory==11.1 ; platform_system == "Darwin" and platform_release >= "17.0"
+pyobjc-framework-fileprovider==11.1 ; platform_system == "Darwin" and platform_release >= "19.0"
+pyobjc-framework-fileproviderui==11.1 ; platform_system == "Darwin" and platform_release >= "19.0"
+pyobjc-framework-findersync==11.1 ; platform_system == "Darwin" and platform_release >= "14.0"
+pyobjc-framework-fsevents==11.1 ; platform_system == "Darwin"
+pyobjc-framework-fskit==11.1 ; platform_system == "Darwin" and platform_release >= "24.4"
+pyobjc-framework-gamecenter==11.1 ; platform_system == "Darwin" and platform_release >= "12.0"
+pyobjc-framework-gamecontroller==11.1 ; platform_system == "Darwin" and platform_release >= "13.0"
+pyobjc-framework-gamekit==11.1 ; platform_system == "Darwin" and platform_release >= "12.0"
+pyobjc-framework-gameplaykit==11.1 ; platform_system == "Darwin" and platform_release >= "15.0"
+pyobjc-framework-healthkit==11.1 ; platform_system == "Darwin" and platform_release >= "22.0"
+pyobjc-framework-imagecapturecore==11.1 ; platform_system == "Darwin" and platform_release >= "10.0"
+pyobjc-framework-inputmethodkit==11.1 ; platform_system == "Darwin" and platform_release >= "9.0"
+pyobjc-framework-installerplugins==11.1 ; platform_system == "Darwin"
+pyobjc-framework-instantmessage==11.1 ; platform_system == "Darwin" and platform_release >= "9.0"
+pyobjc-framework-intents==11.1 ; platform_system == "Darwin" and platform_release >= "16.0"
+pyobjc-framework-intentsui==11.1 ; platform_system == "Darwin" and platform_release >= "21.0"
+pyobjc-framework-iobluetooth==11.1 ; platform_system == "Darwin"
+pyobjc-framework-iobluetoothui==11.1 ; platform_system == "Darwin"
+pyobjc-framework-iosurface==11.1 ; platform_system == "Darwin" and platform_release >= "10.0"
+pyobjc-framework-ituneslibrary==11.1 ; platform_system == "Darwin" and platform_release >= "10.0"
+pyobjc-framework-kernelmanagement==11.1 ; platform_system == "Darwin" and platform_release >= "20.0"
+pyobjc-framework-latentsemanticmapping==11.1 ; platform_system == "Darwin"
+pyobjc-framework-launchservices==11.1 ; platform_system == "Darwin"
+pyobjc-framework-libdispatch==11.1 ; platform_system == "Darwin" and platform_release >= "12.0"
+pyobjc-framework-libxpc==11.1 ; platform_system == "Darwin" and platform_release >= "12.0"
+pyobjc-framework-linkpresentation==11.1 ; platform_system == "Darwin" and platform_release >= "19.0"
+pyobjc-framework-localauthentication==11.1 ; platform_system == "Darwin" and platform_release >= "14.0"
+pyobjc-framework-localauthenticationembeddedui==11.1 ; platform_system == "Darwin" and platform_release >= "21.0"
+pyobjc-framework-mailkit==11.1 ; platform_system == "Darwin" and platform_release >= "21.0"
+pyobjc-framework-mapkit==11.1 ; platform_system == "Darwin" and platform_release >= "13.0"
+pyobjc-framework-mediaaccessibility==11.1 ; platform_system == "Darwin" and platform_release >= "13.0"
+pyobjc-framework-mediaextension==11.1 ; platform_system == "Darwin" and platform_release >= "24.0"
+pyobjc-framework-medialibrary==11.1 ; platform_system == "Darwin" and platform_release >= "13.0"
+pyobjc-framework-mediaplayer==11.1 ; platform_system == "Darwin" and platform_release >= "16.0"
+pyobjc-framework-mediatoolbox==11.1 ; platform_system == "Darwin" and platform_release >= "13.0"
+pyobjc-framework-metal==11.1 ; platform_system == "Darwin" and platform_release >= "15.0"
+pyobjc-framework-metalfx==11.1 ; platform_system == "Darwin" and platform_release >= "22.0"
+pyobjc-framework-metalkit==11.1 ; platform_system == "Darwin" and platform_release >= "15.0"
+pyobjc-framework-metalperformanceshaders==11.1 ; platform_system == "Darwin" and platform_release >= "17.0"
+pyobjc-framework-metalperformanceshadersgraph==11.1 ; platform_system == "Darwin" and platform_release >= "20.0"
+pyobjc-framework-metrickit==11.1 ; platform_system == "Darwin" and platform_release >= "21.0"
+pyobjc-framework-mlcompute==11.1 ; platform_system == "Darwin" and platform_release >= "20.0"
+pyobjc-framework-modelio==11.1 ; platform_system == "Darwin" and platform_release >= "15.0"
+pyobjc-framework-multipeerconnectivity==11.1 ; platform_system == "Darwin" and platform_release >= "14.0"
+pyobjc-framework-naturallanguage==11.1 ; platform_system == "Darwin" and platform_release >= "18.0"
+pyobjc-framework-netfs==11.1 ; platform_system == "Darwin" and platform_release >= "10.0"
+pyobjc-framework-network==11.1 ; platform_system == "Darwin" and platform_release >= "18.0"
+pyobjc-framework-networkextension==11.1 ; platform_system == "Darwin" and platform_release >= "15.0"
+pyobjc-framework-notificationcenter==11.1 ; platform_system == "Darwin" and platform_release >= "14.0"
+pyobjc-framework-opendirectory==11.1 ; platform_system == "Darwin" and platform_release >= "10.0"
+pyobjc-framework-osakit==11.1 ; platform_system == "Darwin"
+pyobjc-framework-oslog==11.1 ; platform_system == "Darwin" and platform_release >= "19.0"
+pyobjc-framework-passkit==11.1 ; platform_system == "Darwin" and platform_release >= "20.0"
+pyobjc-framework-pencilkit==11.1 ; platform_system == "Darwin" and platform_release >= "19.0"
+pyobjc-framework-phase==11.1 ; platform_system == "Darwin" and platform_release >= "21.0"
+pyobjc-framework-photos==11.1 ; platform_system == "Darwin" and platform_release >= "15.0"
+pyobjc-framework-photosui==11.1 ; platform_system == "Darwin" and platform_release >= "15.0"
+pyobjc-framework-preferencepanes==11.1 ; platform_system == "Darwin"
+pyobjc-framework-pubsub==11.1 ; platform_release >= "9.0" and platform_release < "18.0" and platform_system == "Darwin"
+pyobjc-framework-pushkit==11.1 ; platform_system == "Darwin" and platform_release >= "19.0"
+pyobjc-framework-quartz==11.1 ; platform_system == "Darwin"
+pyobjc-framework-quicklookthumbnailing==11.1 ; platform_system == "Darwin" and platform_release >= "19.0"
+pyobjc-framework-replaykit==11.1 ; platform_system == "Darwin" and platform_release >= "20.0"
+pyobjc-framework-safariservices==11.1 ; platform_system == "Darwin" and platform_release >= "16.0"
+pyobjc-framework-safetykit==11.1 ; platform_system == "Darwin" and platform_release >= "22.0"
+pyobjc-framework-scenekit==11.1 ; platform_system == "Darwin" and platform_release >= "11.0"
+pyobjc-framework-screencapturekit==11.1 ; platform_system == "Darwin" and platform_release >= "21.4"
+pyobjc-framework-screensaver==11.1 ; platform_system == "Darwin"
+pyobjc-framework-screentime==11.1 ; platform_system == "Darwin" and platform_release >= "20.0"
+pyobjc-framework-scriptingbridge==11.1 ; platform_system == "Darwin" and platform_release >= "9.0"
+pyobjc-framework-searchkit==11.1 ; platform_system == "Darwin"
+pyobjc-framework-security==11.1 ; platform_system == "Darwin"
+pyobjc-framework-securityfoundation==11.1 ; platform_system == "Darwin"
+pyobjc-framework-securityinterface==11.1 ; platform_system == "Darwin"
+pyobjc-framework-securityui==11.1 ; platform_system == "Darwin" and platform_release >= "24.4"
+pyobjc-framework-sensitivecontentanalysis==11.1 ; platform_system == "Darwin" and platform_release >= "23.0"
+pyobjc-framework-servicemanagement==11.1 ; platform_system == "Darwin" and platform_release >= "10.0"
+pyobjc-framework-sharedwithyou==11.1 ; platform_system == "Darwin" and platform_release >= "22.0"
+pyobjc-framework-sharedwithyoucore==11.1 ; platform_system == "Darwin" and platform_release >= "22.0"
+pyobjc-framework-shazamkit==11.1 ; platform_system == "Darwin" and platform_release >= "21.0"
+pyobjc-framework-social==11.1 ; platform_system == "Darwin" and platform_release >= "12.0"
+pyobjc-framework-soundanalysis==11.1 ; platform_system == "Darwin" and platform_release >= "19.0"
+pyobjc-framework-speech==11.1 ; platform_system == "Darwin" and platform_release >= "19.0"
+pyobjc-framework-spritekit==11.1 ; platform_system == "Darwin" and platform_release >= "13.0"
+pyobjc-framework-storekit==11.1 ; platform_system == "Darwin" and platform_release >= "11.0"
+pyobjc-framework-symbols==11.1 ; platform_system == "Darwin" and platform_release >= "23.0"
+pyobjc-framework-syncservices==11.1 ; platform_system == "Darwin"
+pyobjc-framework-systemconfiguration==11.1 ; platform_system == "Darwin"
+pyobjc-framework-systemextensions==11.1 ; platform_system == "Darwin" and platform_release >= "19.0"
+pyobjc-framework-threadnetwork==11.1 ; platform_system == "Darwin" and platform_release >= "22.0"
+pyobjc-framework-uniformtypeidentifiers==11.1 ; platform_system == "Darwin" and platform_release >= "20.0"
+pyobjc-framework-usernotifications==11.1 ; platform_system == "Darwin" and platform_release >= "18.0"
+pyobjc-framework-usernotificationsui==11.1 ; platform_system == "Darwin" and platform_release >= "20.0"
+pyobjc-framework-videosubscriberaccount==11.1 ; platform_system == "Darwin" and platform_release >= "18.0"
+pyobjc-framework-videotoolbox==11.1 ; platform_system == "Darwin" and platform_release >= "12.0"
+pyobjc-framework-virtualization==11.1 ; platform_system == "Darwin" and platform_release >= "20.0"
+pyobjc-framework-vision==11.1 ; platform_system == "Darwin" and platform_release >= "17.0"
+pyobjc-framework-webkit==11.1 ; platform_system == "Darwin"
+pyqt6==6.9.1
+pyqt6-frameless-window==0.7.3
+pyqt6-qt6==6.9.1
+pyqt6-sip==13.10.2
+pyqtgraph==0.13.7
+python-dateutil==2.9.0.post0
+python-dotenv==1.1.0
+pytz==2025.2
+pywin32==310 ; platform_system == "Windows"
+pywin32-ctypes==0.2.3 ; sys_platform == "win32"
+pyyaml==6.0.2
+qasync==0.24.2
+setuptools==80.9.0
+six==1.17.0
+sqlcipher3-wheels==0.5.4.post0
+structlog==23.3.0
+tzdata==2025.2
+wcwidth==0.2.13
+yarl==1.20.0

--- a/tools/export_requirements.py
+++ b/tools/export_requirements.py
@@ -1,0 +1,75 @@
+"""Utility for exporting Poetry's main dependencies to requirements.txt.
+
+This is a minimal drop-in replacement for ``poetry export`` when the
+``poetry-plugin-export`` plugin is unavailable (e.g. in offline
+environments). The script reads ``poetry.lock`` and writes a
+``requirements.txt`` that contains the pinned runtime dependencies from
+the ``main`` dependency group while preserving platform markers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+if sys.version_info < (3, 11):
+    raise SystemExit("Python 3.11 or newer is required to parse poetry.lock")
+
+import tomllib
+
+
+def build_requirements(lock_path: Path) -> list[str]:
+    """Return sorted requirement specifiers from a Poetry lock file."""
+    data = tomllib.loads(lock_path.read_text())
+    lines: list[tuple[str, str]] = []
+    for package in data.get("package", []):
+        groups = package.get("groups", [])
+        if "main" not in groups:
+            continue
+
+        marker = package.get("markers")
+        if isinstance(marker, dict):
+            marker = marker.get("main")
+
+        name = package["name"]
+        version = package["version"]
+        requirement = f"{name}=={version}"
+        if marker:
+            requirement = f"{requirement} ; {marker}"
+
+        lines.append((name.lower(), requirement))
+
+    return [entry for _, entry in sorted(lines)]
+
+
+def write_requirements(requirements: list[str], output_path: Path) -> None:
+    header = "# This requirements.txt was generated from poetry.lock.\n"
+    output_path.write_text(header + "\n".join(requirements) + "\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--lock",
+        type=Path,
+        default=Path("poetry.lock"),
+        help="Path to the Poetry lock file (default: poetry.lock)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("requirements.txt"),
+        help="Target requirements.txt file (default: requirements.txt)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    requirements = build_requirements(args.lock)
+    write_requirements(requirements, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- regenerate requirements.txt from poetry.lock so runtime dependencies match Poetry's main group
- add an export_requirements helper for offline environments and document the workflow for keeping requirements.txt in sync

## Testing
- python -m compileall tools/export_requirements.py

------
https://chatgpt.com/codex/tasks/task_e_68cd4deafe78832494ca7e8107a7e632